### PR TITLE
+ 使用fs-extra依赖 无缝替代fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "md-editor",
 	"version": "0.0.0",
 	"main": "src/main.js",
+	"dependencies": {
+		"fs-extra": "^0.27.0"  
+	},
 	"devDependencies": {
 		"gulp": "^3.8.11",
 		"gulp-atom": "^0.1.0"

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@ var app = require('app');
 var BrowserWindow = require('browser-window');  
 var ipc = require('ipc');
 var dialog = require('dialog');
-var fs = require('fs');
+var fs = require('fs-extra'); // 为了添加一个npm依赖 @ES
 
 require('crash-reporter').start();
 


### PR DESCRIPTION
原因: 项目需要 在bower依赖的基础上 新增npm依赖 @ES
